### PR TITLE
feat(services): 丁寧なスクレイピングのためのキャッシュとUser-Agentを実装

### DIFF
--- a/lib/services/contest_service.dart
+++ b/lib/services/contest_service.dart
@@ -4,13 +4,16 @@ import 'package:yaml/yaml.dart';
 import '../models/contest.dart';
 
 class ContestService {
+  static const String _userAgent =
+      'ShojinApp/1.0 (+https://github.com/yuubinnkyoku/Shojin_App)';
+  static const _headers = {'User-Agent': _userAgent};
   static const String _contestUrl =
       'https://github.com/yuubinnkyoku/atcoder-contest-info/raw/refs/heads/main/contests.yaml';
 
   /// すべてのコンテスト情報を取得
   Future<List<Contest>> fetchAllContests() async {
     try {
-      final response = await http.get(Uri.parse(_contestUrl));
+      final response = await http.get(Uri.parse(_contestUrl), headers: _headers);
 
       if (response.statusCode == 200) {
         // UTF-8でデコード


### PR DESCRIPTION
### feat(services): 丁寧なスクレイピングのためのキャッシュとUser-Agentを実装

このコミットは、アプリケーションのスクレイピング動作を改善し、AtCoderサーバーへの負荷を考慮した、より効率的で丁寧なものにするための2つの主要な改善を導入します。

1.  **問題ページのキャッシングを実装**
    `AtCoderService`に`CacheManager`を導入し、問題ページのHTMLコンテンツを24時間キャッシュするようにしました。これにより、最近閲覧した問題に対する不要なGETリクエストが大幅に減少し、AtCoderサーバーの負荷を軽減します。サービスは、ネットワークから新たに取得する前に、まず有効なキャッシュが存在するかどうかを確認します。

2.  **カスタムUser-Agentの追加**
    `AtCoderService`および`ContestService`からのすべてのHTTPリクエストに、カスタム`User-Agent`ヘッダー (`ShojinApp/1.0 (+https://github.com/yuubinnkyoku/Shojin_App)`) を含めるようにしました。これは、アプリケーションからのトラフィックを識別可能にするもので、丁寧なWebスクレイピングにおける標準的な作法です。